### PR TITLE
Fix Python test

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -36,7 +36,8 @@ then
     pkgname="$(rpmspec -q --qf="Magics-%{version}-%{release}\n" Magics.spec | head -n1)"
     mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
     cp Magics.spec ~/rpmbuild/SPECS/
-    spectool -g -R ~/rpmbuild/SPECS/Magics.spec
+    cp *.patch ~/rpmbuild/SOURCES/
+    spectool -g -R -S ~/rpmbuild/SPECS/Magics.spec
     set +x
     rpmbuild -ba ~/rpmbuild/SPECS/Magics.spec 2>&1 | pv -q -L 3k
     find ~/rpmbuild/{RPMS,SRPMS}/ -name "${pkgname}*rpm" -exec cp -v {} . \;

--- a/Magics.spec
+++ b/Magics.spec
@@ -14,6 +14,7 @@ URL:            http://www.ecmwf.int/products/data/software/magics++.html
 Source0:        https://software.ecmwf.int/wiki/download/attachments/3473464/%{name}-%{version}-Source.tar.gz
 Patch0:         https://raw.githubusercontent.com/ARPA-SIMC/Magics-rpm/v%{version}-%{releaseno}/magics-fix-warnings.patch
 Patch1:         https://raw.githubusercontent.com/ARPA-SIMC/Magics-rpm/v%{version}-%{releaseno}/magics-rm-ksh.patch
+Patch2:         https://raw.githubusercontent.com/ARPA-SIMC/Magics-rpm/v%{version}-%{releaseno}/magics-python-load-libMagPlus.patch
 License:        Apache License, Version 2.0
 
 BuildRequires:  gcc-c++
@@ -90,6 +91,7 @@ Python modules for Magics - The library and tools to visualize meteorological da
 %setup -q -n %{name}-%{version}-Source
 %patch0
 %patch1
+%patch2
 
 %build
 

--- a/Magics.spec
+++ b/Magics.spec
@@ -122,7 +122,7 @@ popd
 pushd build
 # MAGPLUS_HOME is needed for the tests to work, see:
 # https://software.ecmwf.int/wiki/display/MAGP/Installation+Guide
-MAGPLUS_HOME=%{buildroot} CTEST_OUTPUT_ON_FAILURE=1 ctest
+MAGPLUS_HOME=%{buildroot} CTEST_OUTPUT_ON_FAILURE=1 LD_LIBRARY_PATH=%{buildroot}%{_libdir} ctest
 popd
 
 %install

--- a/Magics.spec
+++ b/Magics.spec
@@ -118,14 +118,12 @@ pushd build
 %{make_build}
 popd
 
-#check
-# temporarily disabled:
-# see https://github.com/ARPA-SIMC/Magics-rpm/issues/1
-#pushd build
-## MAGPLUS_HOME is needed for the tests to work, see:
-## https://software.ecmwf.int/wiki/display/MAGP/Installation+Guide
-#MAGPLUS_HOME=%{buildroot} CTEST_OUTPUT_ON_FAILURE=1 ctest
-#popd
+%check
+pushd build
+# MAGPLUS_HOME is needed for the tests to work, see:
+# https://software.ecmwf.int/wiki/display/MAGP/Installation+Guide
+MAGPLUS_HOME=%{buildroot} CTEST_OUTPUT_ON_FAILURE=1 ctest
+popd
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/magics-python-load-libMagPlus.patch
+++ b/magics-python-load-libMagPlus.patch
@@ -18,7 +18,7 @@ diff -up python/Magics.py.in.orig python/Magics.py.in
 +# First, search in LD_LIBRARY_PATH
 +for d in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
 +    p = os.path.join(d, "libMagPlus.so")
-+    if os.path.exists(p)
++    if os.path.exists(p):
 +        lib = path
 +
 +# Then, search in system directory

--- a/magics-python-load-libMagPlus.patch
+++ b/magics-python-load-libMagPlus.patch
@@ -19,7 +19,7 @@ diff -up python/Magics.py.in.orig python/Magics.py.in
 +for d in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
 +    p = os.path.join(d, "libMagPlus.so")
 +    if os.path.exists(p):
-+        lib = path
++        lib = p
 +
 +# Then, search in system directory
 +if lib is None:

--- a/magics-python-load-libMagPlus.patch
+++ b/magics-python-load-libMagPlus.patch
@@ -1,0 +1,36 @@
+diff -up python/Magics.py.in.orig python/Magics.py.in
+--- python/Magics.py.in.orig	2018-04-24 16:24:53.896107691 +0200
++++ python/Magics.py.in	2018-04-24 16:50:48.135792575 +0200
+@@ -10,17 +10,28 @@
+ import ctypes
+ import ctypes.util
+ import sys
++import os
+ 
+ import numpy as np
+ from numpy.ctypeslib import ndpointer
+ from functools import partial
+ 
+-lib = ctypes.util.find_library("MagPlus")
+ 
++lib = None
++
++# First, search in LD_LIBRARY_PATH
++for d in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
++    p = os.path.join(d, "libMagPlus.so")
++    if os.path.exists(p)
++        lib = path
++
++# Then, search in system directory
++if lib is None:
++    lib = ctypes.util.find_library("MagPlus")
++
++# Finally, raise exception if the library is missing
+ if lib is None:
+-    lib = "@CMAKE_INSTALL_PREFIX@/@INSTALL_LIB_DIR@/libMagPlus@CMAKE_SHARED_LIBRARY_SUFFIX@"
+-    if lib is None:
+-      lib = "@CMAKE_BINARY_DIR@/lib/libMagPlus@CMAKE_SHARED_LIBRARY_SUFFIX@"
++    raise Exception("Cannot find libMagPlus.so")
+ 
+ dll  = ctypes.CDLL(lib)
+ libc = ctypes.CDLL(ctypes.util.find_library("c"))

--- a/magics-python-load-libMagPlus.patch
+++ b/magics-python-load-libMagPlus.patch
@@ -1,7 +1,7 @@
 diff -up python/Magics.py.in.orig python/Magics.py.in
 --- python/Magics.py.in.orig	2018-04-24 16:24:53.896107691 +0200
-+++ python/Magics.py.in	2018-04-24 16:50:48.135792575 +0200
-@@ -10,17 +10,28 @@
++++ python/Magics.py.in	2018-04-24 18:30:33.771219330 +0200
+@@ -10,17 +10,29 @@
  import ctypes
  import ctypes.util
  import sys
@@ -20,6 +20,7 @@ diff -up python/Magics.py.in.orig python/Magics.py.in
 +    p = os.path.join(d, "libMagPlus.so")
 +    if os.path.exists(p):
 +        lib = p
++        break
 +
 +# Then, search in system directory
 +if lib is None:


### PR DESCRIPTION
Unfortunately, [the build log is too big for Travis][1] so I can't prove that this PR is ok, but *It Works On My Computer ™*

```
Executing(%check): /bin/sh -e /var/tmp/rpm-tmp.BXKk7L
+ umask 022
+ cd /home/edg/rpmbuild/BUILD
+ cd Magics-3.0.3-Source
+ pushd build
~/rpmbuild/BUILD/Magics-3.0.3-Source/build ~/rpmbuild/BUILD/Magics-3.0.3-Source
+ MAGPLUS_HOME=/home/edg/rpmbuild/BUILDROOT/Magics-3.0.3-1.fc27.x86_64
+ CTEST_OUTPUT_ON_FAILURE=1
+ LD_LIBRARY_PATH=/home/edg/rpmbuild/BUILDROOT/Magics-3.0.3-1.fc27.x86_64/usr/lib64
+ ctest
Test project /home/edg/rpmbuild/BUILD/Magics-3.0.3-Source/build
    Start 1: basic_c
1/9 Test #1: basic_c ..........................   Passed    0.45 sec
    Start 2: basic_python
2/9 Test #2: basic_python .....................   Passed    4.64 sec
    Start 3: basic_fortran_shared
3/9 Test #3: basic_fortran_shared .............   Passed    0.09 sec
    Start 4: bufr_python
4/9 Test #4: bufr_python ......................   Passed    0.75 sec
    Start 5: bufr_fortran
5/9 Test #5: bufr_fortran .....................   Passed    0.08 sec
    Start 6: grib_python
6/9 Test #6: grib_python ......................   Passed    1.57 sec
    Start 7: grib_fortran
7/9 Test #7: grib_fortran .....................   Passed    0.29 sec
    Start 8: cairo_python
8/9 Test #8: cairo_python .....................   Passed    0.83 sec
    Start 9: cairo_fortran
9/9 Test #9: cairo_fortran ....................   Passed    0.12 sec

100% tests passed, 0 tests failed out of 9

Label Time Summary:
executable    =   1.03 sec*proc (5 tests)
magics        =   8.81 sec*proc (9 tests)
python        =   7.79 sec*proc (4 tests)

Total Test time (real) =   8.89 sec
+ popd
~/rpmbuild/BUILD/Magics-3.0.3-Source
+ exit 0
```

**Note** 53cd19022a17ab3dd63792cacc581137264c5fe5 introduces a nice feature: `.travis-build.sh` apply the upstream version patches instead of the last tagged version ones.

[1]: https://api.travis-ci.org/v3/job/370658923/log.txt