### PR TITLE
Disable some verbose compiler warnings

### DIFF
--- a/Magics.spec
+++ b/Magics.spec
@@ -99,7 +99,7 @@ mkdir build
 pushd build
 
 %cmake .. \
-    -DCMAKE_CXX_FLAGS"$CXXFLAGS -Wno-deprecated-declarations -Wno-deprecated-declarations" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-deprecated-declarations -Wno-deprecated-declarations" \
     -DCMAKE_PREFIX_PATH=%{_prefix} \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DINSTALL_LIB_DIR=%{_lib} \

--- a/Magics.spec
+++ b/Magics.spec
@@ -99,7 +99,7 @@ mkdir build
 pushd build
 
 %cmake .. \
-    -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-deprecated-declarations -Wno-deprecated-declarations" \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-deprecated-declarations -Wno-unused-local-typedefs" \
     -DCMAKE_PREFIX_PATH=%{_prefix} \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DINSTALL_LIB_DIR=%{_lib} \

--- a/Magics.spec
+++ b/Magics.spec
@@ -99,6 +99,7 @@ mkdir build
 pushd build
 
 %cmake .. \
+    -DCMAKE_CXX_FLAGS"$CXXFLAGS -Wno-deprecated-declarations -Wno-deprecated-declarations" \
     -DCMAKE_PREFIX_PATH=%{_prefix} \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DINSTALL_LIB_DIR=%{_lib} \


### PR DESCRIPTION
The warnings `unused-local-typedefs` and `deprecated-declarations` are disabled in the specfile. This means that we'll never see these warnings in Copr too or in local packaging.

A possibile alternative is using a macro and activating it only in `.travis-build.sh`. What do you think @brancomat ?

Fix #3 
